### PR TITLE
Update Stablebaselines3 to 2.1.0

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -15,7 +15,7 @@
 - git:
     local-name: ../utils-extern/misc/stable-baselines3
     uri: https://github.com/tuananhroman/stable-baselines3.git
-    version: master
+    version: update
 
 - git:
     local-name: ../utils-extern/ros/navigation/msgs/ford

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ seaborn = "^0.12.2"
 netifaces = "^0.11.0"
 tensorboard = "^2.12.2"
 stable-baselines3 = {path = "../utils-extern/misc/stable-baselines3", develop = true}
-sb3-contrib = "^1.8.0"
 torchdiffeq = "^0.2.3"
 diffcp = "^1.0.21"
 cvxpy = "^1.3.0"
@@ -27,6 +26,7 @@ cvxpylayers = "^0.1.5"
 mpi4py = "^3.1.4"
 gputil = "^1.4.0"
 tensorboardx = "^2.6"
+gym = "^0.22"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Makes gym version 0.21 as dependency redundant, therefore removed. Poetry install should run through cleanly now.