### PR TITLE
Add TaskMode GUIDED

### DIFF
--- a/task_generator/task_generator/constants.py
+++ b/task_generator/task_generator/constants.py
@@ -46,6 +46,7 @@ class Constants:
         PARAMETRIZED = "parametrized"
         DYNAMIC_MAP_RANDOM = "dynamic_map_random"
         DYNAMIC_MAP_STAGED = "dynamic_map_staged"
+        GUIDED = "guided"
 
     class MapGenerator:
         NODE_NAME = "map_generator"

--- a/task_generator/task_generator/manager/robot_manager.py
+++ b/task_generator/task_generator/manager/robot_manager.py
@@ -40,6 +40,10 @@ class RobotManager:
     _goal_pos: PositionOrientation
 
     @property
+    def start_pos(self) -> PositionOrientation:
+        return self._start_pos
+
+    @property
     def goal_pos(self) -> PositionOrientation:
         return self._goal_pos
     
@@ -154,24 +158,24 @@ class RobotManager:
         self._entity_manager.move_robot(
             name=self._robot.name, position=position)
 
-    def reset(self, start_pos: Optional[PositionOrientation], goal_pos: PositionOrientation):
+    def reset(self, start_pos: Optional[PositionOrientation], goal_pos: Optional[PositionOrientation]):
         """
         Publishes start and goal to data_recorder, publishes goal to move_base
         """
 
-        if start_pos is None:
-            start_pos = self._start_pos
-        else:
+        if start_pos is not None:
+            self._start_pos = start_pos
             self.move_robot_to_pos(start_pos)
 
-        self._start_pos, self._goal_pos = start_pos, goal_pos
+            if self._robot.record_data:
+                rospy.set_param(self.namespace("goal"), list(self._goal_pos))
 
-        if self._robot.record_data:
-            rospy.set_param(self.namespace("goal"), str(list(self._goal_pos)))
-            rospy.set_param(self.namespace("start"),
-                            str(list(self._start_pos)))
+        if goal_pos is not None:
+            self._goal_pos = goal_pos
+            self._publish_goal(self._goal_pos)
 
-        self._publish_goal(self._goal_pos)
+            if self._robot.record_data:
+                rospy.set_param(self.namespace("start"), list(self._start_pos))
 
         time.sleep(0.1)
 

--- a/task_generator/task_generator/manager/robot_manager.py
+++ b/task_generator/task_generator/manager/robot_manager.py
@@ -38,6 +38,11 @@ class RobotManager:
 
     _start_pos: PositionOrientation
     _goal_pos: PositionOrientation
+
+    @property
+    def goal_pos(self) -> PositionOrientation:
+        return self._goal_pos
+    
     _position: PositionOrientation
 
     _robot_radius: float

--- a/task_generator/task_generator/simulators/gazebo_simulator.py
+++ b/task_generator/task_generator/simulators/gazebo_simulator.py
@@ -16,7 +16,7 @@ from task_generator.constants import Constants
 from task_generator.simulators.base_simulator import BaseSimulator
 from task_generator.simulators.simulator_factory import SimulatorFactory
 
-from task_generator.shared import ModelType
+from task_generator.shared import ModelType, RobotProps
 
 
 T = Constants.WAIT_FOR_SERVICE_TIMEOUT
@@ -116,10 +116,11 @@ class GazeboSimulator(BaseSimulator):
         request.robot_namespace = self._namespace(entity.name)
         request.reference_frame = "world"
 
-        rospy.set_param(request.robot_namespace(
-            "robot_description"), model.description)
-        rospy.set_param(request.robot_namespace(
-            "tf_prefix"), str(request.robot_namespace))
+        if isinstance(entity, RobotProps):
+            rospy.set_param(request.robot_namespace(
+                "robot_description"), model.description)
+            rospy.set_param(request.robot_namespace(
+                "tf_prefix"), str(request.robot_namespace))
 
         res = self.spawn_model(model.type, request)
 

--- a/task_generator/task_generator/tasks/__init__.py
+++ b/task_generator/task_generator/tasks/__init__.py
@@ -9,3 +9,4 @@ from .staged import StagedTask  # noqa
 from .parametrized import ParametrizedTask  # noqa
 from .dynamic_map_random import DynamicMapRandomTask  # noqa
 from .dynamic_map_staged import DynamicMapStagedTask  # noqa
+from .guided import GuidedTask # noqa

--- a/task_generator/task_generator/tasks/guided.py
+++ b/task_generator/task_generator/tasks/guided.py
@@ -56,7 +56,7 @@ class GuidedTask(BaseTask):
         self.iters = 0
         self._is_done = False
 
-        self._waypoints = [(self.map_manager._origin.x, self.map_manager._origin.y, 0)]
+        self._waypoints = []
         self._waypoint_states = {robot.name:0 for robot in self.robot_managers}
         self._reset_waypoints()
 
@@ -115,9 +115,10 @@ class GuidedTask(BaseTask):
 
         for robot in self.robot_managers:
             if robot.is_done:
+                waypoints = self._waypoints or [robot.goal_pos]
                 self._waypoint_states[robot.name] += 1
-                self._waypoint_states[robot.name] %= len(self._waypoints)
-                robot.reset(start_pos=None, goal_pos=self._waypoints[self._waypoint_states[robot.name]])
+                self._waypoint_states[robot.name] %= len(waypoints)
+                robot.reset(start_pos=None, goal_pos=waypoints[self._waypoint_states[robot.name]])
 
         if self._is_done:
             self._is_done = False

--- a/utils/misc/rviz_utils/config/rviz_default.yaml
+++ b/utils/misc/rviz_utils/config/rviz_default.yaml
@@ -66,7 +66,7 @@ Visualization Manager:
       X std deviation: 0.5
       Y std deviation: 0.5
     - Class: rviz/SetGoal
-      Topic: /move_base_simple/goal
+      Topic: /goalpose
     - Class: rviz/PublishPoint
       Single click: true
       Topic: /clicked_point


### PR DESCRIPTION
Manually set a cyclical sequence of goal waypoints for the robot using rviz.

Manual:
- Launch with `roslaunch arena_bringup start_arena.launch simulator:=flatland map_file:=map_empty task_mode:=guided robot_setup_file:=demo.yaml`
- Use the `2D Nav Goal` tool to append a goal position to the sequence
- Make the robots drive in a circle or similar
- Use the `Publish Point` tool anywhere to trigger a full reset

Features:
- derived from task_mode:=random (identical behavior except for robots)
- robots stay still and wait until first goal is published
- full multi-robot support (robots share the list of waypoints, but track them individually)
- compatible with all simulators and planners
- goal sequence is tracked in rosparam `/guided_waypoints`