### PR TITLE
Arena-Unity Launching

### DIFF
--- a/arena_bringup/launch/start_arena.launch
+++ b/arena_bringup/launch/start_arena.launch
@@ -115,9 +115,11 @@
 
   <!-- Unity -->
   <arg name="development_mode" default="false" />
+  <arg name="headless" default="false" />
   <include file="$(find arena_bringup)/launch/testing/simulators/unity.launch" if="$(eval arg('simulator') == 'unity')">
     <arg name="world" default="$(arg world_file)" />
     <arg name="development_mode" value="$(arg development_mode)" />
+    <arg name="headless" value="$(arg headless)" />
   </include>
 
   <!-- map server-->

--- a/arena_bringup/launch/start_arena.launch
+++ b/arena_bringup/launch/start_arena.launch
@@ -114,9 +114,10 @@
   </include>
 
   <!-- Unity -->
+  <arg name="development_mode" default="false" />
   <include file="$(find arena_bringup)/launch/testing/simulators/unity.launch" if="$(eval arg('simulator') == 'unity')">
     <arg name="world" default="$(arg world_file)" />
-    <arg name="dev_mode" default="false">
+    <arg name="development_mode" value="$(arg development_mode)" />
   </include>
 
   <!-- map server-->

--- a/arena_bringup/launch/start_arena.launch
+++ b/arena_bringup/launch/start_arena.launch
@@ -116,7 +116,7 @@
   <!-- Unity -->
   <include file="$(find arena_bringup)/launch/testing/simulators/unity.launch" if="$(eval arg('simulator') == 'unity')">
     <arg name="world" default="$(arg world_file)" />
-    <arg name="development_mode" default="false">
+    <arg name="dev_mode" default="false">
   </include>
 
   <!-- map server-->

--- a/arena_bringup/launch/start_arena.launch
+++ b/arena_bringup/launch/start_arena.launch
@@ -116,6 +116,7 @@
   <!-- Unity -->
   <include file="$(find arena_bringup)/launch/testing/simulators/unity.launch" if="$(eval arg('simulator') == 'unity')">
     <arg name="world" default="$(arg world_file)" />
+    <arg name="development_mode" default="false">
   </include>
 
   <!-- map server-->

--- a/arena_bringup/launch/testing/simulators/unity.launch
+++ b/arena_bringup/launch/testing/simulators/unity.launch
@@ -25,4 +25,5 @@
         type="load_world_service.py" 
         output="screen"
     /> -->
+  <node name="unity_sim_node" pkg="unity_launcher" type="launch_unity_sim.py" output="screen"/>
 </launch>

--- a/arena_bringup/launch/testing/simulators/unity.launch
+++ b/arena_bringup/launch/testing/simulators/unity.launch
@@ -2,7 +2,6 @@
 <launch>
   <arg name="world" default="turtlebot3_house" />
   <arg name="model" default="burger"/>
-  <arg name="headless" default="false"/>
   <arg name="gui" default="true"/>
   <arg name="show_rviz" default="true" doc="Wether to show rviz or not" />
   <arg name="tcp_ip" default="0.0.0.0"/>
@@ -21,9 +20,11 @@
   </include>
 
   <arg name="development_mode" default="false" />
+  <arg name="headless" default="false"/>
 
   <node name="unity_sim_node" pkg="unity_launcher" type="launch_unity_sim.py" output="screen">
     <param name="development_mode" value="$(arg development_mode)" />
+    <param name="headless" value="$(arg headless)" />
   </node>
 
 </launch>

--- a/arena_bringup/launch/testing/simulators/unity.launch
+++ b/arena_bringup/launch/testing/simulators/unity.launch
@@ -19,11 +19,11 @@
   <include file="$(find arena_bringup)/launch/utils/rviz.launch">
     <arg name="show_rviz" value="$(arg show_rviz)" />
   </include>
-  <!-- <node 
-        pkg="unity_utils" 
-        name="load_world_service" 
-        type="load_world_service.py" 
-        output="screen"
-    /> -->
-  <node name="unity_sim_node" pkg="unity_launcher" type="launch_unity_sim.py" output="screen"/>
+
+  <arg name="dev_mode" default="false"/>
+
+  <node name="unity_sim_node" pkg="unity_launcher" type="launch_unity_sim.py" output="screen">
+    <param name="dev_mode" value="$(arg dev_mode)" />
+  </node>
+
 </launch>

--- a/arena_bringup/launch/testing/simulators/unity.launch
+++ b/arena_bringup/launch/testing/simulators/unity.launch
@@ -20,10 +20,10 @@
     <arg name="show_rviz" value="$(arg show_rviz)" />
   </include>
 
-  <arg name="dev_mode" default="false"/>
+  <arg name="development_mode" default="false" />
 
   <node name="unity_sim_node" pkg="unity_launcher" type="launch_unity_sim.py" output="screen">
-    <param name="dev_mode" value="$(arg dev_mode)" />
+    <param name="development_mode" value="$(arg development_mode)" />
   </node>
 
 </launch>

--- a/task_generator/task_generator/simulators/unity_simulator.py
+++ b/task_generator/task_generator/simulators/unity_simulator.py
@@ -77,7 +77,8 @@ class UnitySimulator(BaseSimulator):
         request.model_xml = model.description
         request.robot_namespace = self._namespace(entity.name)
         request.reference_frame = "world"
-        # Keep in mind that y axis is up
+
+        # send coordinates in the normal ROS refrence frame (FLU)
         request.initial_pose = Pose(
             position=Point(
                 x=entity.position[0],

--- a/utils/misc/unity_launcher/CMakeLists.txt
+++ b/utils/misc/unity_launcher/CMakeLists.txt
@@ -1,0 +1,204 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(unity_launcher)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+# add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a exec_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs  # Or other packages containing msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES unity_launcher
+#  CATKIN_DEPENDS rospy
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+# include
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ library
+# add_library(${PROJECT_NAME}
+#   src/${PROJECT_NAME}/unity_launcher.cpp
+# )
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+# add_executable(${PROJECT_NAME}_node src/unity_launcher_node.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(${PROJECT_NAME}_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# catkin_install_python(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables for installation
+## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html
+# install(TARGETS ${PROJECT_NAME}_node
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark libraries for installation
+## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_libraries.html
+# install(TARGETS ${PROJECT_NAME}
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_unity_launcher.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/utils/misc/unity_launcher/package.xml
+++ b/utils/misc/unity_launcher/package.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>unity_launcher</name>
+  <version>0.0.0</version>
+  <description>The unity_launcher package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="maxmilian@todo.todo">maxmilian</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/unity_launcher</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rospy</build_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <exec_depend>rospy</exec_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/utils/misc/unity_launcher/src/launch_unity_sim.py
+++ b/utils/misc/unity_launcher/src/launch_unity_sim.py
@@ -11,14 +11,25 @@ def launch_unity():
     """
     rospy.init_node('unity_sim_node', anonymous=True)
 
+    rospy.logerr(rospy.get_param('~development_mode', 'valls'))
+    rospy.logerr(rospy.get_param('/dev_mode', 'xalls'))
+    rospy.logerr(rospy.get_param('dev_mode', 'yalls'))
+
+    dev = rospy.get_param('~development_mode', False)
+    if isinstance(dev, bool) and dev:
+        # Unity should be launched trough Unity Editor in dev mode
+        return
+
     # find unity executable
     current_path = os.path.dirname(os.path.abspath(__file__))
     ws_src_path = os.path.join(current_path, "../../../../..")
     unity_executable_path = os.path.join(ws_src_path, "arena-unity/Build/arena-unity")
-    
+
     # args
     args = list()
-    arena_sim_setup_path = ["-arena_sim_setup_path", os.path.join(ws_src_path, "arena-simulation-setup")]
+    arena_sim_setup_path = [
+        "-arena_sim_setup_path", os.path.join(ws_src_path, "arena-simulation-setup")
+    ]
     args += arena_sim_setup_path
 
     subprocess.run([unity_executable_path] + args, check=True)

--- a/utils/misc/unity_launcher/src/launch_unity_sim.py
+++ b/utils/misc/unity_launcher/src/launch_unity_sim.py
@@ -11,11 +11,6 @@ def launch_unity():
     """
     rospy.init_node('unity_sim_node', anonymous=True)
 
-    rospy.logerr(rospy.get_param('~development_mode', 'valls'))
-    rospy.logerr(rospy.get_param('~headless', 'raaahh'))
-    rospy.logerr(rospy.get_param('/dev_mode', 'xalls'))
-    rospy.logerr(rospy.get_param('dev_mode', 'yalls'))
-
     dev = rospy.get_param('~development_mode', False)
     if isinstance(dev, bool) and dev:
         # Unity should be launched trough Unity Editor in dev mode
@@ -29,15 +24,12 @@ def launch_unity():
     # args
     args = list()
     args += [
-        "-arena_sim_setup_path", 
+        "-arena_sim_setup_path",
         os.path.join(ws_src_path, "arena-simulation-setup")
     ]
     headless = rospy.get_param('~headless', False)
     if isinstance(headless, bool) and headless:
-        rospy.logerr("AAAAHAHAHAAHAHAH")
         args += ["-batchmode"]
-
-    rospy.logerr(args)
 
     subprocess.run([unity_executable_path] + args, check=True)
 

--- a/utils/misc/unity_launcher/src/launch_unity_sim.py
+++ b/utils/misc/unity_launcher/src/launch_unity_sim.py
@@ -11,8 +11,6 @@ def launch_unity():
     """
     rospy.init_node('unity_sim_node', anonymous=True)
 
-    unity_executable_path = "/path/to/your/project.x86_64"
-
     # find unity executable
     current_path = os.path.dirname(os.path.abspath(__file__))
     ws_src_path = os.path.join(current_path, "../../../../..")

--- a/utils/misc/unity_launcher/src/launch_unity_sim.py
+++ b/utils/misc/unity_launcher/src/launch_unity_sim.py
@@ -12,6 +12,7 @@ def launch_unity():
     rospy.init_node('unity_sim_node', anonymous=True)
 
     rospy.logerr(rospy.get_param('~development_mode', 'valls'))
+    rospy.logerr(rospy.get_param('~headless', 'raaahh'))
     rospy.logerr(rospy.get_param('/dev_mode', 'xalls'))
     rospy.logerr(rospy.get_param('dev_mode', 'yalls'))
 
@@ -27,10 +28,16 @@ def launch_unity():
 
     # args
     args = list()
-    arena_sim_setup_path = [
-        "-arena_sim_setup_path", os.path.join(ws_src_path, "arena-simulation-setup")
+    args += [
+        "-arena_sim_setup_path", 
+        os.path.join(ws_src_path, "arena-simulation-setup")
     ]
-    args += arena_sim_setup_path
+    headless = rospy.get_param('~headless', False)
+    if isinstance(headless, bool) and headless:
+        rospy.logerr("AAAAHAHAHAAHAHAH")
+        args += ["-batchmode"]
+
+    rospy.logerr(args)
 
     subprocess.run([unity_executable_path] + args, check=True)
 

--- a/utils/misc/unity_launcher/src/launch_unity_sim.py
+++ b/utils/misc/unity_launcher/src/launch_unity_sim.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""This module handles the launch of the unity simulator"""
+
+import subprocess
+import os
+import rospy
+
+
+def launch_unity():
+    """Launches the unity executable with given arguments
+    """
+    rospy.init_node('unity_sim_node', anonymous=True)
+
+    unity_executable_path = "/path/to/your/project.x86_64"
+
+    # find unity executable
+    current_path = os.path.dirname(os.path.abspath(__file__))
+    ws_src_path = os.path.join(current_path, "../../../../..")
+    unity_executable_path = os.path.join(ws_src_path, "arena-unity/Build/arena-unity")
+
+    subprocess.run([unity_executable_path], check=True)
+
+
+if __name__ == '__main__':
+    try:
+        launch_unity()
+    except rospy.ROSInterruptException:
+        pass

--- a/utils/misc/unity_launcher/src/launch_unity_sim.py
+++ b/utils/misc/unity_launcher/src/launch_unity_sim.py
@@ -15,8 +15,13 @@ def launch_unity():
     current_path = os.path.dirname(os.path.abspath(__file__))
     ws_src_path = os.path.join(current_path, "../../../../..")
     unity_executable_path = os.path.join(ws_src_path, "arena-unity/Build/arena-unity")
+    
+    # args
+    args = list()
+    arena_sim_setup_path = ["-arena_sim_setup_path", os.path.join(ws_src_path, "arena-simulation-setup")]
+    args += arena_sim_setup_path
 
-    subprocess.run([unity_executable_path], check=True)
+    subprocess.run([unity_executable_path] + args, check=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
These commits add the logic for launching Arena-Unity directly through arena-core together with the corresponding commit form the Arena-Unity repo.

A new ROS package for launching Arena-Unity was added. This package is called from the unity launch file which in turn is called by the start_arena.launch.

Notice that the Arena-Unity project must be build through the script as explained in the Arena-Unity PR.

Arguments:
- development_mode:=true  -  this stops arena-core from launching Unity when Unity is the simulator. For development, when Arena-Unity should be started manually through the Unity Editor. Default: false
- headless:=true  -  this starts Arena-Unity in headless mode. The window still pops up but there is nothing displayed and user input is ignored. Default: false

Example launch:
roslaunch arena_bringup start_arena.launch simulator:=unity task_mode:=scenario model:=burger map_file:=map_empty
