### PR TITLE
fix training launch

### DIFF
--- a/arena_bringup/launch/testing/move_base/mbf_nav/costmap_nav.launch
+++ b/arena_bringup/launch/testing/move_base/mbf_nav/costmap_nav.launch
@@ -8,6 +8,8 @@
     <arg name="inter_planner" />
     <arg name="local_planner" />
 
+    <arg name="agent_name" default="$(arg model)" if="$(eval arg('local_planner') == 'rosnav')" />
+
     <include file="$(find arena_bringup)/launch/testing/move_base/planners/local/mbf_$(arg local_planner).launch">
         <arg name="model" value="$(arg model)" />
         <arg name="speed" value="$(arg speed)" />

--- a/arena_bringup/launch/testing/robot.launch
+++ b/arena_bringup/launch/testing/robot.launch
@@ -15,8 +15,7 @@
   <arg name="SIMULATOR" default="flatland" />
 
   <arg name="train_mode" default="false" doc="If false, start the Rosnav Deployment Nodes" />
-  <arg name="agent_name" default="$(arg name)" doc="DRL agent name to be deployed"
-    unless="$(eval arg('local_planner') != 'rosnav')" />
+  <arg name="agent_name" default="$(arg name)" doc="DRL agent name to be deployed" if="$(eval arg('local_planner') == 'rosnav')" />
 
   <arg name="complexity" default="1" />
 
@@ -81,9 +80,7 @@
         <arg name="local_planner" value="$(arg local_planner)" />
 
         <arg name="model" value="$(arg model)" />
-        <arg name="train_mode" value="$(arg train_mode)" if="$(eval arg('local_planner') == 'rosnav')" />
         <arg name="agent_name" value="$(arg agent_name)" if="$(eval arg('local_planner') == 'rosnav')" />
-        <arg name="sim_namespace" value="$(arg sim_namespace)" if="$(eval arg('local_planner') == 'rosnav')" />
 
         <arg name="namespace" value="$(arg namespace)" />
         <arg name="frame" value="$(arg name)/" />

--- a/arena_bringup/launch/training/train_robot.launch
+++ b/arena_bringup/launch/training/train_robot.launch
@@ -7,6 +7,8 @@
   <arg name="model" default="" />
   <arg name="namespace" default="" />
   <arg name="sim_namespace" default="" />
+
+  <arg name="inter_planner" default="bypass" />
   <arg name="local_planner" default="rosnav" />
 
   <arg name="train_mode" default="false" doc="If false, start the Rosnav Deployment Nodes"/>
@@ -36,16 +38,15 @@
       <remap from="cmd_vel" to="$(arg namespace)/cmd_vel" />
       <remap from="odom" to="$(arg namespace)/odom" />
 
-      <include file="$(find arena_bringup)/launch/testing/move_base/bootstrap.launch">
+      <include file="$(find arena_bringup)/launch/testing/move_base/mbf_nav/costmap_nav.launch">
+
+        <arg name="inter_planner" value="$(arg inter_planner)" />
         <arg name="local_planner" value="$(arg local_planner)" />
 
         <arg name="model" value="$(arg model)" />
-        <arg name="train_mode" value="$(arg train_mode)" />
-        <arg name="agent_name" value="$(arg agent_name)" />
+        <arg name="agent_name" value="$(arg agent_name)" if="$(eval arg('local_planner') == 'rosnav')" />
 
         <arg name="namespace" value="$(arg namespace)" />
-        <arg name="sim_namespace" value="$(arg sim_namespace)" />
-
         <arg name="frame" value="$(arg name)/" />
 
       </include>


### PR DESCRIPTION
- add `inter_planner` arg to `train_robot.launch`
- remove `train_mode` and `sim_namespace` from `mbf_costmap_nav.launch` since they aren't used there