### PR TITLE
Updated Arena Unity download link to latest release

### DIFF
--- a/install4_arena_unity.sh
+++ b/install4_arena_unity.sh
@@ -22,9 +22,7 @@ if [ -d $build_path ]; then
 fi
 
 # Download Arena-Unity-Build.tar.gz
-# TODO: Change this link once the arena-unity PR is accepted and the new release made official
-url="https://github.com/Arena-Rosnav/arena-unity/releases/download/v1.0/$file_name"
-# url="https://github.com/Arena-Rosnav/arena-unity/releases/latest/download/$file_name"
+url="https://github.com/Arena-Rosnav/arena-unity/releases/latest/download/$file_name"
 echo "*** Downloading latest release"
 wget $url || { echo "Error: Download failed"; exit 1; }
 


### PR DESCRIPTION
Made Arena Unity build an official release and now adjusted path accordingly. 

No changes with Arena Unity/Arena Rosnav, still same build.

install4 script will now always download the latest official release from arena-unity repo.